### PR TITLE
Pass str(path) to PyTables

### DIFF
--- a/components/tools/OmeroPy/src/omero/tables.py
+++ b/components/tools/OmeroPy/src/omero/tables.py
@@ -217,7 +217,7 @@ class HdfStorage(object):
         try:
             if self.__hdf_path.exists() and self.__hdf_path.size == 0:
                 mode = "w"
-            return tables.openFile(self.__hdf_path, mode=mode,\
+            return tables.openFile(str(self.__hdf_path), mode=mode,\
                 title="OMERO HDF Measurement Storage", rootUEP="/")
         except (tables.HDF5ExtError, IOError), io:
             msg = "HDFStorage initialized with bad path: %s" % self.__hdf_path


### PR DESCRIPTION
Passing a `path.path` object to `openFile` leads to:

```
2014-06-30 07:37:04,920 INFO  [                            omero.remote] (Dummy-3   )  Excp: Expected bytes, got path
Traceback (most recent call last):
  File "/opt/ome1/dist/lib/python/omero/util/decorators.py", line 61, in exc_handler
    rv = func(*args, **kwargs)
  File "/opt/ome1/dist/lib/python/omero/util/decorators.py", line 39, in handler
    rv = func(*args, **kwargs)
  File "/opt/ome1/dist/lib/python/omero/tables.py", line 915, in getTable
    storage = HDFLIST.getOrCreate(file_path)
  File "/opt/ome1/dist/lib/python/omero/util/decorators.py", line 81, in with_lock
    return func(*args, **kwargs)
  File "/opt/ome1/dist/lib/python/omero/tables.py", line 141, in getOrCreate
    return HdfStorage(hdfpath) # Adds itself.
  File "/opt/ome1/dist/lib/python/omero/tables.py", line 184, in __init__
    self.__hdf_file = HDFLIST.addOrThrow(file_path, self)
  File "/opt/ome1/dist/lib/python/omero/util/decorators.py", line 81, in with_lock
    return func(*args, **kwargs)
  File "/opt/ome1/dist/lib/python/omero/tables.py", line 125, in addOrThrow
    hdffile = hdfstorage.openfile("a")
  File "/opt/ome1/dist/lib/python/omero/tables.py", line 217, in openfile
    title="OMERO HDF Measurement Storage", rootUEP="/")
  File "/usr/lib/python2.7/dist-packages/tables/_past.py", line 35, in oldfunc
    return obj(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/tables/file.py", line 318, in open_file
    return File(filename, mode, title, root_uep, filters, **kwargs)
  File "/usr/lib/python2.7/dist-packages/tables/file.py", line 791, in __init__
    self._g_new(filename, mode, **params)
  File "hdf5extension.pyx", line 327, in tables.hdf5extension.File._g_new (tables/hdf5extension.c:3498)
  File "utilsextension.pyx", line 569, in tables.utilsextension.encode_filename (tables/utilsextension.c:4140)
TypeError: Expected bytes, got path
```

Feel free to cherry-pick, etc.
