### PR TITLE
Allow to read configuration

### DIFF
--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1794,9 +1794,12 @@ OMERO Diagnostics %s
         """
 
         config = config.as_map()
-        upgrade_url = config.get(
-            "omero.upgrades.url", "http://upgrade.openmicroscopy.org.uk")
-        uc = UpgradeCheck('server', url=upgrade_url)
+        agent = 'server'
+        upgrade_url = config.get("omero.upgrades.url", None)
+        if upgrade_url:
+            uc = UpgradeCheck(agent, url=upgrade_url)
+        else:
+            uc = UpgradeCheck(agent)
         uc.run()
         if uc.isUpgradeNeeded():
             self.ctx.die(1, uc.getUpgradeUrl())

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1794,7 +1794,7 @@ OMERO Diagnostics %s
         """
 
         config = config.as_map()
-        url = config.get(
+        upgrade_url = config.get(
             "omero.upgrades.url", "http://upgrade.openmicroscopy.org.uk")
         uc = UpgradeCheck('server', url=upgrade_url)
         uc.run()

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1795,7 +1795,7 @@ OMERO Diagnostics %s
 
         config = config.as_map()
         url = config.get(
-            "omero.ugprades.url", "http://upgrade.openmicroscopy.org.uk")
+            "omero.upgrades.url", "http://upgrade.openmicroscopy.org.uk")
         uc = UpgradeCheck('server', url=upgrade_url)
         uc.run()
         if uc.isUpgradeNeeded():

--- a/components/tools/OmeroPy/src/omero/plugins/admin.py
+++ b/components/tools/OmeroPy/src/omero/plugins/admin.py
@@ -1786,12 +1786,17 @@ OMERO Diagnostics %s
         config = config.as_map()
         return config.get("omero.data.dir", "/OMERO")
 
-    def checkupgrade(self, args):
+    @with_config
+    def checkupgrade(self, args, config):
         """
         Checks whether a server upgrade is available,
         exits with return code 1 if yes
         """
-        uc = UpgradeCheck('server')
+
+        config = config.as_map()
+        url = config.get(
+            "omero.ugprades.url", "http://upgrade.openmicroscopy.org.uk")
+        uc = UpgradeCheck('server', url=upgrade_url)
         uc.run()
         if uc.isUpgradeNeeded():
             self.ctx.die(1, uc.getUpgradeUrl())


### PR DESCRIPTION
As we are working through the registry work, I realized extending this `admin checkupgrade` command to read the `omero.upgrades.url` property and pass it to `UpgradeCheck` might be the easiest way to test the Python `UpgradeCheck` logic.
This adds a `with_config` dependency to the subcommand which does not seem unrealistic since this belongs to the `admin` plugin and is meant to be run on the server /cc @aleksandra-tarkowska
